### PR TITLE
Doc repo link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -84,6 +84,7 @@ project = ABOUT_PYLHC["__title__"]
 copyright = "2019-2020, pyLHC/OMC-TEAM"
 author = ABOUT_PYLHC["__author__"]
 
+# Override link in 'Edit on Github'
 rst_prolog = f"""
 :github_url: {ABOUT_PYLHC['__url__']}
 """

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -84,6 +84,10 @@ project = ABOUT_PYLHC["__title__"]
 copyright = "2019-2020, pyLHC/OMC-TEAM"
 author = ABOUT_PYLHC["__author__"]
 
+rst_prolog = f"""
+:github_url: {ABOUT_PYLHC['__url__']}
+"""
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
@@ -124,11 +128,20 @@ html_theme_options = {
     "display_version": True,
     "logo_only": True,
     "navigation_depth": 2,
+    "style_external_links": True,
 }
 
 html_logo = "_static/img/omc_logo.svg"
 html_static_path = ["_static"]
-html_context = {"css_files": ["_static/css/custom.css"]}
+html_show_sourcelink = False
+html_context = {
+    "css_files": ["_static/css/custom.css"],
+    'display_github': True,
+    # the following are only needed if :github_url: is not set
+    'github_user': author,
+    'github_repo': project,
+    'github_version': 'master/doc/',
+}
 
 smartquotes_action = "qe"  # renders only quotes and ellipses (...) but not dashes (option: D)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 Welcome to PyLHC's documentation!
 =================================
 
-``PyLHC`` is a collection of useful scripts and tools for the OMC Team at CERN. `CERN <https://home.cern/>`_.
+``PyLHC`` is a collection of useful scripts and tools for the OMC Team at `CERN <https://home.cern/>`_.
 
 
 Package Reference


### PR DESCRIPTION
Changes  useless "View Source" to "Edit on Github" link at the top right which links directly to the repo