### PR TITLE
Fix find_knobs

### DIFF
--- a/pylhc/data_extract/lsa.py
+++ b/pylhc/data_extract/lsa.py
@@ -16,6 +16,7 @@ from typing import Callable, Union, Dict, Tuple, List
 LOG = logging.getLogger(__name__)
 pytimber = cern_network_import("pytimber")
 pjlsa = cern_network_import("pjlsa")
+
 try:
     pjLSAClient = pjlsa.LSAClient
 except ImportError:
@@ -58,8 +59,8 @@ class LSAClient(pjLSAClient):
         Returns:
             Sorted list of knob names.
         """
-        req = pjlsa.ParametersRequestBuilder()
-        req.setAccelerator(pjlsa.Accelerators.get(accelerator, accelerator))
+        req = self._ParametersRequestBuilder()
+        req.setAccelerator(self._getAccelerator(accelerator))
         req.setParameterTypeName("KNOB")
         lst = self._parameterService.findParameters(req.build())
         reg = re.compile(regexp, re.IGNORECASE)


### PR DESCRIPTION
The finding knobs function (that is, if you don't give any knob names it tries to find all present knobs) didn't work after some updates on pjlsa (probably long ago, but only noticed now).

Luckily my first try to fix it succedded :)



```
 python -m pylhc.machine_settings_info --time "2018-06-16 21:15:00.000"

(...)
----------- Summary ---------------------
Given Time:   2018-06-16 21:15:00 UTC
Fill:         6811
Beamprocess:  SQUEEZE-6.5TeV-ATS-1m-30cm-2018_V1_MD1@638_[END]
  Start:      2018-06-16 14:53:45 UTC
  Context:    MD
  Descr.:     Actual beamprocess for SQUEEZE-6.5TeV-ATS-1m-30cm-2018_V1_MD1@638
Optics:       R2017aT_A30C30A10mL300_CTPPS2
  Start:      2018-06-16 14:53:45 UTC
----------- Trims -----------------------
LHCBEAM/2017_30cm_GlobalCorr_wXing_Beam2_v2: 1
LHCBEAM/2017_ATS_Inj_LocalCoupling: 1
LHCBEAM/2017_ATS_LocalCorrection: 1
LHCBEAM/2017_B2_MQT_total_phase_correction: 1
LHCBEAM/2017_IRNL_IR1a4       : 0.5
LHCBEAM/2017_IRNL_IR1b3_couplFD: 1
LHCBEAM/2017_IRNL_a3b3_tuneFD : 1
LHCBEAM/2017_IRNL_b4          : 1
LHCBEAM/2017_NL_IR1_30cm_kcssxr1: 1
LHCBEAM/2017_beam1_beta_CrossingAngleCompensation: 1
LHCBEAM/2018_IRNL_IR1a3       : 1
LHCBEAM/2018_IRNL_IR1b3       : 1
LHCBEAM/2018_IRNL_IR5a3       : 1
LHCBEAM/B1_2017_MQT_total_phase_correction: 1
LHCBEAM/B2_2017_global_correction_Xing: 1
LHCBEAM/IP1-ANGLE-H-MURAD     : 0
LHCBEAM/IP1-ANGLE-V-MURAD     : 0
LHCBEAM/IP1-OFFSET-H-MM       : 0
LHCBEAM/IP1-OFFSET-V-MM       : 0
LHCBEAM/IP1-SDISP-CORR-SEP    : 0
LHCBEAM/IP1-SDISP-CORR-XING   : 0
LHCBEAM/IP1-SEP-H-MM          : 0
LHCBEAM/IP1-SEP-V-MM          : 0
LHCBEAM/IP1-XING-H-MURAD      : 0
LHCBEAM/IP1-XING-V-MURAD      : 0
LHCBEAM/IP2-ANGLE-H-MURAD     : 0
LHCBEAM/IP2-OFFSET-V-2MM      : 0
LHCBEAM/IP2-OFFSET-V-MM       : 0
LHCBEAM/IP2-SEP-H-MM-RUN2     : 0
LHCBEAM/IP2-XING-V-MURAD      : 0
LHCBEAM/IP5-ANGLE-H-MURAD     : 0
LHCBEAM/IP5-ANGLE-V-MURAD     : 0
LHCBEAM/IP5-OFFSET-H-MM       : 0
LHCBEAM/IP5-OFFSET-V-MM       : -1.8
LHCBEAM/IP5-SDISP-CORR-SEP    : 0
LHCBEAM/IP5-SDISP-CORR-XING   : 0
LHCBEAM/IP5-SEP-H-MM          : 0
LHCBEAM/IP5-SEP-V-MM          : 0.55
LHCBEAM/IP5-XING-H-MURAD      : 160
LHCBEAM/IP5-XING-V-MURAD      : 0
LHCBEAM/IP8-ANGLE-V-MURAD     : 0
LHCBEAM/IP8-OFFSET-H-MM       : 0
LHCBEAM/IP8-SEP-V-MM          : 0
LHCBEAM/IP8-XING-H-MURAD      : 0
LHCBEAM/IR5_a4_2018           : 1
LHCBEAM/b1_global_beta_beating_40cm_ctpps_2017_v2: 1
LHCBEAM/b2_global_beta_beating_40cm_ctpps_2017: 1
LHCBEAM/chromatic_coupling_b1_40cm_ctpps2_2017_v2: -1
LHCBEAM/chromatic_coupling_b2_40cm_ctpps2_2017: -1
LHCBEAM/global_coup_knob_all_correctors: -1
LHCBEAM1/BUMP-4C-BRST-B1H-1MM : 0
LHCBEAM1/BUMP-4C-BRST-B1V-1MM : 0
LHCBEAM1/BUMPV-3C-Q18L2-B1-MM : 0
LHCBEAM1/CMINUS_IM.IP7        : -0.00160788
LHCBEAM1/CMINUS_RE.IP7        : -0.0310912
LHCBEAM1/LANDAU_DAMPING_RUN2  : 0
LHCBEAM1/QH_TRIM              : 0.05968
LHCBEAM1/QH_TRIM_INT          : 0
LHCBEAM1/QPH                  : -4.01019
LHCBEAM1/QPV                  : 7.7043
LHCBEAM1/QV_TRIM              : -0.02092
LHCBEAM1/QV_TRIM_INT          : 0
LHCBEAM1/TELE_QPH             : 2
LHCBEAM1/TELE_QPV             : 2
LHCBEAM2/BUMP-4C-BRST-B2H-1MM : 0
LHCBEAM2/BUMP-4C-BRST-B2V-1MM : 0
LHCBEAM2/BUMPH-3C-Q15R8-MM    : -2
LHCBEAM2/BUMPH-3C-Q18L2-B2-MM : -0.8
LHCBEAM2/BUMPV-4C-Q15R8-MM    : 0
LHCBEAM2/CMINUS_IM.IP7        : 0.0141244
LHCBEAM2/CMINUS_RE.IP7        : -0.0105
LHCBEAM2/LANDAU_DAMPING       : 0
LHCBEAM2/QH_TRIM              : 0.03274
LHCBEAM2/QH_TRIM_INT          : 0
LHCBEAM2/QPH                  : -4.00055
LHCBEAM2/QPV                  : 5.34254
LHCBEAM2/QV_TRIM              : 0.03834
LHCBEAM2/QV_TRIM_INT          : 0
LHCBEAM2/TELE_QPH             : 2
LHCBEAM2/TELE_QPV             : 2
LHCBEAM2/PHASE15_TRIM_H       : 0
LHCBEAM2/PHASE15_TRIM_V       : 0
-----------------------------------------
```