### PR TITLE
Pyjapc pin and warning

### DIFF
--- a/pylhc/__init__.py
+++ b/pylhc/__init__.py
@@ -11,7 +11,7 @@ PyLHC is a script collection for the optics measurements and corrections group (
 __title__ = "pylhc"
 __description__ = "An accelerator physics script collection for the OMC team at CERN."
 __url__ = "https://github.com/pylhc/pylhc"
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/pylhc/bsrt_logger.py
+++ b/pylhc/bsrt_logger.py
@@ -15,10 +15,17 @@ import os
 import pickle
 import sys
 import time
+import warnings
 from pathlib import Path
 
 from omc3.definitions import formats
 from omc3.utils.mock import cern_network_import
+
+warnings.warn(
+    "The pyjapc package has reached end-of-life and is not supported on Python 3.12+. "
+    "On higher Python versions this script will not run.",
+    stacklevel=2
+)
 
 pyjapc = cern_network_import("pyjapc")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ cern = [
   "omc3[cern] >= 0.15",
   "pjlsa >= 0.2",
   "pytimber >= 3.0",  # NXCALS support
-  "pyjapc; python_version < '3.14'",
+  "pyjapc; python_version < '3.12'",
 ]
 test = [
   "pytest>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ cern = [
   "omc3[cern] >= 0.15",
   "pjlsa >= 0.2",
   "pytimber >= 3.0",  # NXCALS support
-  "pyjapc",
+  "pyjapc; python_version < '3.14'",
 ]
 test = [
   "pytest>=7.0",


### PR DESCRIPTION
The `pyjapc` package, which is part of the `[cern]` optional dependencies, has reached its end-of-life.

I have pinned the dependency on `python_version < 3.14` and added a warning straight away in `brst_logger.py` to provide information on this. Realistically, the BRST logger script has not been used in the past 5 years so I don't expect much disruption.

This would be a patch release.


**Note:** I have pinned `< 3.14` for now but I'm waiting on Phil Elson or others to clarify which Python version exactly is the last supported one, officially. I might change this pin again.

With regards to the `Acc-Py` distributions, considering the last one was `3.11`-based (supported) and the new one is `3.14`-based (unsupported) this still works for now.